### PR TITLE
config指定が不要な場合に対応

### DIFF
--- a/lib/combine-spec/combine-spec.js
+++ b/lib/combine-spec/combine-spec.js
@@ -55,7 +55,7 @@ class CombineSpec {
 
     this.setting = {
       root,
-      config    : safeLoadModule(config),
+      config    : (!!config ? safeLoadModule(config) : { }),
       components: safeLoadModule(components)
     };
   }


### PR DESCRIPTION
configが不要な場合はfalseが設定される
その場合に指定パスからモジュールをロードしないように修正